### PR TITLE
fix: plugin.json and hooks.json use incorrect schema format

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,17 +7,8 @@
     "url": "https://x.com/cloudxdev"
   },
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/CloudAI-X/claude-workflow.git"
-  },
-  "bugs": {
-    "url": "https://github.com/CloudAI-X/claude-workflow/issues"
-  },
+  "repository": "https://github.com/CloudAI-X/claude-workflow",
   "homepage": "https://github.com/CloudAI-X/claude-workflow#readme",
-  "engines": {
-    "claude-code": ">=1.0.33"
-  },
   "keywords": [
     "workflow",
     "agents",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,81 +1,83 @@
 {
-  "PreToolUse": [
-    {
-      "matcher": "Edit|Write",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/protect-files.py"
-        },
-        {
-          "type": "command",
-          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security-check.py"
-        }
-      ]
-    },
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/log-commands.sh"
-        }
-      ]
-    }
-  ],
-  "PostToolUse": [
-    {
-      "matcher": "Edit|Write",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/format-on-edit.py"
-        }
-      ]
-    }
-  ],
-  "Notification": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/notify-input.sh"
-        }
-      ]
-    }
-  ],
-  "Stop": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/notify-complete.sh"
-        }
-      ]
-    }
-  ],
-  "SessionStart": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-environment.py"
-        }
-      ]
-    }
-  ],
-  "UserPromptSubmit": [
-    {
-      "matcher": ".*",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-prompt.py"
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/protect-files.py"
+          },
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/security-check.py"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/log-commands.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/format-on-edit.py"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/notify-input.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/notify-complete.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-environment.py"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/validate-prompt.py"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Description
Fixed plugin.json and hooks.json schema validation errors that prevented the plugin from loading in Claude Code v2.0.76.

**plugin.json changes:**
- Changed `repository` from object `{"type": "git", "url": "..."}` to string `"https://github.com/CloudAI-X/claude-workflow"`
- Removed unsupported `bugs` key
- Removed unsupported `engines` key

**hooks.json changes:**
- Wrapped hook definitions in a `"hooks"` key to match the expected schema

Installed plugin is now listed with no errors
<img width="1236" height="153" alt="Screenshot 2026-01-02 at 11 11 07 PM" src="https://github.com/user-attachments/assets/2ba3644e-9da5-4b63-9e89-39a6ad3dd672" />

Reference: https://code.claude.com/docs/en/plugins-reference

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Component Changed
- [ ] Agent(s)
- [ ] Skill(s)
- [x] Hook(s)
- [ ] Output Style(s) / Command(s)
- [ ] Documentation
- [x] Other (plugin.json manifest)

## Testing
Describe how you tested your changes:
- [x] Tested with Claude Code locally
- [x] Verified on macOS
- [ ] Verified on Linux
- [ ] Verified on Windows

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings
- [ ] I have added tests if applicable

## Related Issues
Fixes #3 