### PR TITLE
fix: add allowed-tools declaration to parallel command files

### DIFF
--- a/commands/parallel-analyze.md
+++ b/commands/parallel-analyze.md
@@ -1,4 +1,5 @@
 ---
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task
 description: Multi-perspective analysis using parallel subagents. Analyzes code from architecture, security, performance, and testing viewpoints simultaneously.
 argument-hint: <file or directory to analyze, e.g., "src/api">
 ---

--- a/commands/parallel-review.md
+++ b/commands/parallel-review.md
@@ -1,4 +1,5 @@
 ---
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task
 description: Run parallel code review across multiple directories or files. Uses N subagents simultaneously for faster analysis.
 argument-hint: <directories or files to review in parallel, e.g., "src/auth src/api src/db">
 ---

--- a/commands/verify-changes.md
+++ b/commands/verify-changes.md
@@ -1,4 +1,5 @@
 ---
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task
 description: Comprehensive verification after code changes. Uses Boris Cherny's multi-subagent adversarial approach.
 ---
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`commands/parallel-review.md`, `commands/parallel-analyze.md`, and `commands/verify-changes.md` all spawn subagents using the `Task` tool with `run_in_background: true`, but none of these files declare `allowed-tools` in their YAML frontmatter.

In Claude Code, commands can only access tools that are either declared in `allowed-tools` or inherited from context. Without an `allowed-tools` field that includes `Task`, the command cannot spawn the parallel subagents that are its core feature — the spawning silently fails or is blocked.

## Impact

- `parallel-review.md` — intended to spawn N parallel code reviewers; **nonfunctional without `Task`**
- `parallel-analyze.md` — intended to spawn 4 perspective agents; **nonfunctional without `Task`**
- `verify-changes.md` — intended to spawn 5 verification + 3 adversarial subagents; **nonfunctional without `Task`**

## Fix

Added `allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task` to the frontmatter of all three files, matching the pattern already used by `commands/bootstrap-repo.md` which correctly declares Task.

```yaml
---
allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Task
description: ...
---
```

No logic, prompts, or output formats were changed.