### PR TITLE
fix: remove broken AGENTS.md cross-references from skill files

### DIFF
--- a/skills/convex-backend/SKILL.md
+++ b/skills/convex-backend/SKILL.md
@@ -114,6 +114,3 @@ await ctx.db
 5. **Actions cannot access `ctx.db`** - use runQuery/runMutation instead
 6. **Include type annotations** when calling functions in same file
 
-## Full Compiled Document
-
-For the complete guide with all rules and detailed code examples, see: `AGENTS.md`

--- a/skills/vercel-react-best-practices/SKILL.md
+++ b/skills/vercel-react-best-practices/SKILL.md
@@ -106,9 +106,7 @@ Reference these guidelines when:
 - `advanced-event-handler-refs` - Store event handlers in refs
 - `advanced-use-latest` - useLatest for stable callback refs
 
-## Full Compiled Document
-
-For the complete guide with all rules expanded and detailed code examples, see: `AGENTS.md`
+## Rule Structure
 
 Each rule contains:
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Two skill files contain cross-references to an `AGENTS.md` file that does not exist in the repository:

- **`skills/convex-backend/SKILL.md` (line 119)**: `For the complete guide with all rules and detailed code examples, see: AGENTS.md`
- **`skills/vercel-react-best-practices/SKILL.md` (line 111)**: `For the complete guide with all rules expanded and detailed code examples, see: AGENTS.md`

Neither the plugin root nor either skill directory contains an `AGENTS.md` file. These are dead links that silently truncate the skills for any developer following the cross-reference.

## Impact

- Developers using the `convex-backend` skill see a dead reference where the "full ruleset with detailed code examples" should be — the Convex guidelines appear incomplete.
- Developers using the `vercel-react-best-practices` skill lose access to the promised expanded rule documentation — the skill is effectively truncated at rule summaries.

## Fix

Removed the broken references to the non-existent `AGENTS.md`.

- In `convex-backend/SKILL.md`: removed the entire `## Full Compiled Document` section (it contained only the broken link).
- In `vercel-react-best-practices/SKILL.md`: removed the broken reference line and retitled the section to `## Rule Structure`, preserving the useful "Each rule contains:" list that followed.

The rule summaries and all other content in both SKILL.md files are unchanged.