### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Create `.md` files in `commands/`:
 ---
 allowed-tools: Bash(git:*), Read, Write
 description: What this command does
-argument-hint: [optional arguments]
+argument-hint: "[optional arguments]"
 ---
 
 [Command instructions here]

--- a/commands/add-tests.md
+++ b/commands/add-tests.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(bun:*), Bash(pytest:*), Bash(go:*), Read, Write
 description: Add tests for recently changed files or specified code
-argument-hint: [file path or function name]
+argument-hint: "[file path or function name]"
 ---
 
 ## Context

--- a/commands/commit-push-pr.md
+++ b/commands/commit-push-pr.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Bash(gh:*)
 description: Commit staged changes, push to remote, and create a pull request
-argument-hint: [optional PR title or description hint]
+argument-hint: "[optional PR title or description hint]"
 ---
 
 ## Context

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git add:*), Bash(git commit:*)
 description: Create a conventional commit with auto-generated message
-argument-hint: [optional scope or message hint]
+argument-hint: "[optional scope or message hint]"
 ---
 
 ## Context

--- a/commands/dependency-upgrade.md
+++ b/commands/dependency-upgrade.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(bun:*), Bash(pip:*), Bash(uv:*), Bash(python:*), Bash(cargo:*), Bash(go:*), Read, Edit, WebFetch
 description: Safe, one-at-a-time dependency upgrades with verification after each. Detects package manager automatically.
-argument-hint: [specific package name, or blank for all outdated]
+argument-hint: "[specific package name, or blank for all outdated]"
 ---
 
 # Dependency Upgrade

--- a/commands/lint-fix.md
+++ b/commands/lint-fix.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(bun:*), Bash(python:*), Bash(go:*), Bash(cargo:*)
 description: Auto-fix all linting and formatting issues
-argument-hint: [optional file or directory path]
+argument-hint: "[optional file or directory path]"
 ---
 
 ## Context

--- a/commands/quick-fix.md
+++ b/commands/quick-fix.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(bun:*), Bash(python:*), Bash(pip:*), Bash(go:*), Read, Edit, Write
 description: Quickly fix lint errors, type errors, or simple bugs
-argument-hint: [file or error description]
+argument-hint: "[file or error description]"
 ---
 
 ## Context

--- a/commands/refactor-guided.md
+++ b/commands/refactor-guided.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*), Bash(npm:*), Bash(npx:*), Bash(yarn:*), Bash(pnpm:*), Bash(bun:*), Bash(pytest:*), Bash(python:*), Bash(go:*), Bash(cargo:*), Read, Write, Edit, Glob, Grep
 description: Systematic, safety-first refactoring with verification at each step. Never refactors and adds features simultaneously.
-argument-hint: [target file, directory, or refactoring description]
+argument-hint: "[target file, directory, or refactoring description]"
 ---
 
 # Guided Refactoring

--- a/commands/summarize-changes.md
+++ b/commands/summarize-changes.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*)
 description: Summarize recent changes for standup, PR, or documentation
-argument-hint: [today|week|branch|pr] (default: today)
+argument-hint: "[today|week|branch|pr] (default: today)"
 ---
 
 ## Context

--- a/commands/sync-branch.md
+++ b/commands/sync-branch.md
@@ -1,7 +1,7 @@
 ---
 allowed-tools: Bash(git:*)
 description: Sync current branch with main/master (fetch, rebase or merge)
-argument-hint: [merge|rebase] (default: rebase)
+argument-hint: "[merge|rebase] (default: rebase)"
 ---
 
 ## Context


### PR DESCRIPTION
Closes #24.

## Summary

Purely mechanical single-character transform to 10 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (10)

- `commands/commit.md`
- `commands/lint-fix.md`
- `commands/quick-fix.md`
- `commands/sync-branch.md`
- `commands/commit-push-pr.md`
- `commands/refactor-guided.md`
- `README.md`
- `commands/dependency-upgrade.md`
- `commands/summarize-changes.md`
- `commands/add-tests.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
